### PR TITLE
Support package paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ catkin_python_setup()
 catkin_package(
 #  INCLUDE_DIRS include
 #  LIBRARIES gazebo2rviz
-#  CATKIN_DEPENDS rospy
+  CATKIN_DEPENDS rospy pysdf rospkg
 #  DEPENDS system_lib
 )
 

--- a/launch/gazebo2marker.launch
+++ b/launch/gazebo2marker.launch
@@ -1,5 +1,12 @@
 <launch>
-  <node name="gazebo2marker" pkg="gazebo2rviz" type="gazebo2marker_node.py" output="screen">
+  <arg name="frequency" default="2" />
+  <arg name="collision" default="false" />
+
+  <arg name="collision_arg" value="-c" if="$(arg collision)" />
+  <arg name="collision_arg" value="" unless="$(arg collision)" />
+
+
+  <node name="gazebo2marker" pkg="gazebo2rviz" type="gazebo2marker_node.py" args="-f $(arg frequency) $(arg collision_arg)" output="screen">
     <param name="ignore_submodels_of" value="" type="str" />
   </node>
 </launch>

--- a/launch/gazebo2rviz.launch
+++ b/launch/gazebo2rviz.launch
@@ -1,4 +1,10 @@
 <launch>
+  <arg name="marker_frequency" default="2" />
+  <arg name="marker_collision" default="false" />
+
   <include file="$(find gazebo2rviz)/launch/gazebo2tf.launch" />
-  <include file="$(find gazebo2rviz)/launch/gazebo2marker.launch" />
+  <include file="$(find gazebo2rviz)/launch/gazebo2marker.launch">
+    <arg name="frequency" value="$(arg marker_frequency)" />
+    <arg name="collision" value="$(arg marker_collision)" />
+  </include>
 </launch>

--- a/package.xml
+++ b/package.xml
@@ -13,6 +13,7 @@
   <build_depend>pysdf</build_depend>
   <run_depend>pysdf</run_depend>
   <run_depend>rospy</run_depend>
+  <run_depend>rospkg</run_depend>
 
   <export>
   </export>


### PR DESCRIPTION
Added a further fallback option for interpreting model:// resource paths.

This expects the URI to be of form model://package_name/path_to_resource.
package_name is converted to path using `rospack find`.

This is what I use for seamless conversion of URDF files to SDF using `gz sdf`. I've written a gazebo plugin that enables interpretation of these paths in Gazebo, which I will probably publish in the future, because I consider it very handy.
