### PR TITLE
B fix dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,8 +11,8 @@ catkin_python_setup()
 catkin_package(
 #  INCLUDE_DIRS include
 #  LIBRARIES gazebo2rviz
-  CATKIN_DEPENDS rospy pysdf rospkg
-#  DEPENDS system_lib
+  CATKIN_DEPENDS rospy pysdf
+  DEPENDS python-rospkg
 )
 
 

--- a/package.xml
+++ b/package.xml
@@ -13,7 +13,7 @@
   <build_depend>pysdf</build_depend>
   <run_depend>pysdf</run_depend>
   <run_depend>rospy</run_depend>
-  <run_depend>rospkg</run_depend>
+  <run_depend>python-rospkg</run_depend>
 
   <export>
   </export>


### PR DESCRIPTION
Rosdep can't find the dependency `rospkg`. The right dependency here would be `python-rospkg`, as can be seen [here](https://github.com/ros/rosdistro/blob/master/rosdep/python.yaml#L2054).